### PR TITLE
Environment update, custom css and dropdown menu bg-color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 _site
 .ruby-version
 Gemfile.lock
+.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
+
 gem 'github-pages'
-gem 'jekyll-sitemap'

--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@ Open311 Specs and Wiki
 Open311 specifications and related documentation. 
 
 (the new source of wiki.open311.org)
+
+
+== Installation
+
+Clone from github
+
+    bundle install
+	bundle exec jekyll serve -w
+	
+You are now running the site locally. Checkout [http://localhost:4000][http://localhost:4000]

--- a/_includes/themes/bootstrap-3/default.html
+++ b/_includes/themes/bootstrap-3/default.html
@@ -18,6 +18,8 @@
     
     <!-- Custom styles -->
     <link href="{{ ASSET_PATH }}/css/style.css?body=1" rel="stylesheet" type="text/css" media="all">
+	
+	<link href="/assets/css/open311.css" rel="stylesheet" type="text/css" media="all">
 
 
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.3/styles/default.min.css">

--- a/_includes/themes/twitter/default.html
+++ b/_includes/themes/twitter/default.html
@@ -17,6 +17,7 @@
     <!-- Le styles -->
     <link href="{{ ASSET_PATH }}/bootstrap/css/bootstrap.2.2.2.min.css" rel="stylesheet">
     <link href="{{ ASSET_PATH }}/css/style.css?body=1" rel="stylesheet" type="text/css" media="all">
+	<link href="/assets/css/open311.css" rel="stylesheet" type="text/css" media="all">
 
     <!-- Le fav and touch icons -->
   <!-- Update these with your own images

--- a/assets/css/open311.css
+++ b/assets/css/open311.css
@@ -1,0 +1,4 @@
+
+.dropdown-menu {
+  background-color: #FAB639;
+}


### PR DESCRIPTION
Changed gems to be latest github-pages, added custom css file, updated dropdown menu bg-color.

Requiring jekyll-sitemap was forcing github pages to be on version 15 instead of the latest 29
