### PR TITLE
Updated URL for City of Chicago Open311 docs

### DIFF
--- a/data/servers.yml
+++ b/data/servers.yml
@@ -265,7 +265,7 @@
   gov_domain: true
 - name: "Chicago, IL"
   country: "USA"
-  api_documentation: "http://dev.cityofchicago.org/docs/api"
+  api_documentation: "http://dev.cityofchicago.org/docs/open311/"
   api_issue_tracker: "https://github.com/open311/open311.github.io/issues?q=is%3Aopen+is%3Aissue+label%3Acityofchicago.org"
   api_key_request: "http://311api.cityofchicago.org/open311/v2/apps/new"
   jurisdiction_id: "cityofchicago.org"


### PR DESCRIPTION
City of Chicago re-organized their development page and placed Open311 documentation at a different URL. Content is mostly the same, but the layout of the URLs are different. The underlying mkdocs files to render documentation are available at https://github.com/Chicago/open311-api-docs.